### PR TITLE
Fix evaluation endpoint missing note handling

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -102,7 +102,7 @@ def evaluate_problem(qid):
             if score < 0 or score > 2:
                 return jsonify({"error": f"Invalid score for {k}: {score}"}), 400
             setattr(problem, k, score)
-    problem.evaluation_note = data["evaluation_note"]
+    problem.evaluation_note = data.get("evaluation_note")
     db.session.commit()
     return jsonify(q_to_dict(problem, full=True))
 


### PR DESCRIPTION
## Summary
- avoid crash when `evaluation_note` is omitted

## Testing
- `python -m py_compile backend/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb03bcdd88328950f228708908c49