### PR TITLE
Fix variable typo in OpenAI client

### DIFF
--- a/backend/openai_client.py
+++ b/backend/openai_client.py
@@ -5,9 +5,9 @@ from config import Config
 client = OpenAI(api_key=Config.OPENAI_API_KEY)
 
 def generate_problem(full_objs: str, task_desc: str, technologies: str, target_objs: str, type: str):
-    prompt_tempalate = load_prompt_template(type)
-    
-    prompt = prompt_tempalate.format(
+    prompt_template = load_prompt_template(type)
+
+    prompt = prompt_template.format(
         full_learning_objectives=full_objs,
         task_description=task_desc,
         technologies=technologies,


### PR DESCRIPTION
## Summary
- fix variable typo in `openai_client.py`

## Testing
- `python -m py_compile backend/openai_client.py`


------
https://chatgpt.com/codex/tasks/task_e_683fb1d89b488328b49091e87314b920