### PR TITLE
Add user login and evaluation stats

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,8 @@ from flask import Flask
 from config import Config
 from database import db
 from routes import api
+from models import User
+from werkzeug.security import generate_password_hash
 
 
 def create_app():
@@ -11,6 +13,14 @@ def create_app():
     db.init_app(app)
     with app.app_context():
         db.create_all()
+        if not User.query.first():
+            admin = User(
+                username="admin",
+                password_hash=generate_password_hash("admin"),
+                is_admin=True,
+            )
+            db.session.add(admin)
+            db.session.commit()
 
     app.register_blueprint(api, url_prefix="/api")
 
@@ -22,3 +32,4 @@ def create_app():
 
 if __name__ == "__main__":
     create_app().run(debug=True)
+

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,6 +18,7 @@ class Problem(db.Model):
     prompt = db.Column(db.Text, nullable=False)
     generated_problem = db.Column(db.Text, nullable=False)
     sample_answer = db.Column(db.Text)
+    # legacy columns kept for backwards compatibility but no longer used
     scenario = db.Column(db.Integer)
     alignment = db.Column(db.Integer)
     complexity = db.Column(db.Integer)
@@ -25,3 +26,26 @@ class Problem(db.Model):
     feasibility = db.Column(db.Integer)
     evaluation_note = db.Column(db.Text)
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    evaluations = db.relationship("Evaluation", backref="problem", cascade="all, delete-orphan")
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    is_admin = db.Column(db.Boolean, default=False)
+    evaluations = db.relationship("Evaluation", backref="user", cascade="all, delete-orphan")
+
+
+class Evaluation(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    problem_id = db.Column(db.Integer, db.ForeignKey("problem.id"), nullable=False)
+    scenario = db.Column(db.Integer)
+    alignment = db.Column(db.Integer)
+    complexity = db.Column(db.Integer)
+    clarity = db.Column(db.Integer)
+    feasibility = db.Column(db.Integer)
+    evaluation_note = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,9 +1,79 @@
-from flask import Blueprint, request, jsonify, abort
+from flask import Blueprint, request, jsonify, abort, session
+from functools import wraps
+from werkzeug.security import generate_password_hash, check_password_hash
 from database import db
-from models import Project, Problem
+from models import Project, Problem, User, Evaluation
 from openai_client import generate_problem, generate_answer
 
 api = Blueprint("api", __name__)
+
+
+def current_user():
+    uid = session.get("user_id")
+    if not uid:
+        return None
+    return User.query.get(uid)
+
+
+def login_required(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        if not current_user():
+            abort(401)
+        return f(*args, **kwargs)
+    return wrapper
+
+
+def admin_required(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        user = current_user()
+        if not user or not user.is_admin:
+            abort(403)
+        return f(*args, **kwargs)
+    return wrapper
+
+
+# ---- Authentication ----
+
+@api.route("/login", methods=["POST"])
+def login():
+    data = request.json or {}
+    user = User.query.filter_by(username=data.get("username")).first()
+    if not user or not check_password_hash(user.password_hash, data.get("password", "")):
+        abort(401)
+    session["user_id"] = user.id
+    return jsonify({"username": user.username, "is_admin": user.is_admin})
+
+
+@api.route("/logout", methods=["POST"])
+def logout():
+    session.pop("user_id", None)
+    return "", 204
+
+
+@api.route("/current_user")
+def get_current_user_route():
+    user = current_user()
+    if not user:
+        return jsonify(None)
+    return jsonify({"id": user.id, "username": user.username, "is_admin": user.is_admin})
+
+
+@api.route("/register", methods=["POST"])
+@admin_required
+def register_user():
+    data = request.json or {}
+    if not data.get("username") or not data.get("password"):
+        abort(400)
+    if User.query.filter_by(username=data["username"]).first():
+        return jsonify({"error": "Username already exists"}), 400
+    user = User(username=data["username"],
+                password_hash=generate_password_hash(data["password"]),
+                is_admin=bool(data.get("is_admin")))
+    db.session.add(user)
+    db.session.commit()
+    return jsonify({"id": user.id, "username": user.username, "is_admin": user.is_admin}), 201
 
 # ---- Projects ----
 @api.route("/projects", methods=["GET"])
@@ -39,7 +109,67 @@ def update_project(pid):
 @api.route("/projects/<int:pid>")
 def get_project(pid):
     p = Project.query.get_or_404(pid)
-    return jsonify(p_to_dict(p, with_problems=True))
+    user = current_user()
+    return jsonify(p_to_dict(p, user=user, with_problems=True))
+
+
+@api.route("/projects/<int:pid>/stats")
+@login_required
+def project_stats(pid):
+    project = Project.query.get_or_404(pid)
+    user = current_user()
+    metrics = ["scenario", "alignment", "complexity", "clarity", "feasibility"]
+
+    user_evals = Evaluation.query.join(Problem).filter(
+        Evaluation.user_id == user.id,
+        Problem.project_id == pid
+    ).all()
+
+    def avg_for(evals, field):
+        vals = [getattr(e, field) for e in evals if getattr(e, field) is not None]
+        return sum(vals) / len(vals) if vals else None
+
+    user_avg = {m: avg_for(user_evals, m) for m in metrics}
+
+    overall_avg = None
+    kappa = None
+    if user.is_admin:
+        all_evals = Evaluation.query.join(Problem).filter(Problem.project_id == pid).all()
+        overall_avg = {m: avg_for(all_evals, m) for m in metrics}
+
+        # build evaluations by user and problem
+        evaluations_by_user = {}
+        for ev in all_evals:
+            evaluations_by_user.setdefault(ev.user_id, {})[ev.problem_id] = ev
+
+        def cohen_kappa(r1, r2):
+            n = len(r1)
+            if n == 0:
+                return None
+            categories = [0, 1, 2]
+            po = sum(1 for a, b in zip(r1, r2) if a == b) / n
+            p1 = {c: r1.count(c) / n for c in categories}
+            p2 = {c: r2.count(c) / n for c in categories}
+            pe = sum(p1[c] * p2[c] for c in categories)
+            return 1.0 if pe == 1 else (po - pe) / (1 - pe)
+
+        from itertools import combinations
+        kappa_vals = {m: [] for m in metrics}
+        users = list(evaluations_by_user.keys())
+        for u1, u2 in combinations(users, 2):
+            probs = set(evaluations_by_user[u1].keys()) & set(evaluations_by_user[u2].keys())
+            if not probs:
+                continue
+            for m in metrics:
+                r1 = [getattr(evaluations_by_user[u1][pid], m) for pid in probs if getattr(evaluations_by_user[u1][pid], m) is not None and getattr(evaluations_by_user[u2][pid], m) is not None]
+                r2 = [getattr(evaluations_by_user[u2][pid], m) for pid in probs if getattr(evaluations_by_user[u1][pid], m) is not None and getattr(evaluations_by_user[u2][pid], m) is not None]
+                if len(r1):
+                    score = cohen_kappa(r1, r2)
+                    if score is not None:
+                        kappa_vals[m].append(score)
+        kappa = {m: (sum(v)/len(v) if v else None) for m, v in kappa_vals.items()}
+
+    return jsonify({"user_avg": user_avg, "overall_avg": overall_avg, "kappa": kappa})
 
 
 # ---- Problems ----
@@ -79,9 +209,11 @@ def create_problem(pid):
 
 
 @api.route("/problems/<int:qid>")
+@login_required
 def get_problem(qid):
     q = Problem.query.get_or_404(qid)
-    return jsonify(q_to_dict(q, full=True))
+    user = current_user()
+    return jsonify(q_to_dict(q, user=user, full=True))
 
 
 @api.route("/problems/<int:qid>", methods=["DELETE"])
@@ -93,18 +225,24 @@ def delete_problem(qid):
 
 
 @api.route("/problems/<int:qid>/evaluate", methods=["POST"])
+@login_required
 def evaluate_problem(qid):
     problem = Problem.query.get_or_404(qid)
+    user = current_user()
     data = request.json or {}
+    evaluation = Evaluation.query.filter_by(problem_id=qid, user_id=user.id).first()
+    if not evaluation:
+        evaluation = Evaluation(problem_id=qid, user_id=user.id)
     for k in ["scenario", "alignment", "complexity", "clarity", "feasibility"]:
         if k in data:
             score = int(data[k])
             if score < 0 or score > 2:
                 return jsonify({"error": f"Invalid score for {k}: {score}"}), 400
-            setattr(problem, k, score)
-    problem.evaluation_note = data.get("evaluation_note")
+            setattr(evaluation, k, score)
+    evaluation.evaluation_note = data.get("evaluation_note")
+    db.session.add(evaluation)
     db.session.commit()
-    return jsonify(q_to_dict(problem, full=True))
+    return jsonify(q_to_dict(problem, user=user, full=True))
 
 
 @api.route("/problems/<int:qid>/answer", methods=["POST"])
@@ -116,7 +254,7 @@ def answer_problem(qid):
 
 # ---- Helpers ----
 
-def p_to_dict(p: Project, with_problems=False):
+def p_to_dict(p: Project, user=None, with_problems=False):
     d = {
         "id": p.id,
         "name": p.name,
@@ -127,10 +265,11 @@ def p_to_dict(p: Project, with_problems=False):
         "created_at": p.created_at.isoformat(),
     }
     if with_problems:
-        d["problems"] = [q_to_dict(q) for q in p.problems]
+        d["problems"] = [q_to_dict(q, user=user) for q in p.problems]
     return d
 
-def q_to_dict(q: Problem, full=False):
+
+def q_to_dict(q: Problem, user=None, full=False):
     d = {
         "id": q.id,
         "project_id": q.project_id,
@@ -138,14 +277,26 @@ def q_to_dict(q: Problem, full=False):
         "target_objectives": q.target_objectives,
         "generated_problem": q.generated_problem,
         "sample_answer": q.sample_answer,
-        "scenario": q.scenario,
-        "alignment": q.alignment,
-        "complexity": q.complexity,
-        "clarity": q.clarity,
-        "feasibility": q.feasibility,
-        "evaluation_note": q.evaluation_note,
         "created_at": q.created_at.isoformat(),
     }
+
+    metrics = ["scenario", "alignment", "complexity", "clarity", "feasibility", "evaluation_note"]
+    if user:
+        ev = Evaluation.query.filter_by(problem_id=q.id, user_id=user.id).first()
+        if ev:
+            for m in metrics:
+                d[m] = getattr(ev, m)
+        else:
+            for m in metrics:
+                d[m] = None
+        if user.is_admin:
+            d["all_evaluations"] = [
+                {
+                    "user_id": e.user_id,
+                    **{m: getattr(e, m) for m in metrics}
+                }
+                for e in q.evaluations
+            ]
     if full:
         d["prompt"] = q.prompt
     return d

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,6 +2,19 @@
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">LLM Exam Design Problem App</a>
+      <ul class="navbar-nav ms-auto" v-if="user">
+        <li class="nav-item" v-if="user.is_admin">
+          <RouterLink class="nav-link" to="/register">Add User</RouterLink>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#" @click.prevent="doLogout">Logout ({{ user.username }})</a>
+        </li>
+      </ul>
+      <ul class="navbar-nav ms-auto" v-else>
+        <li class="nav-item">
+          <RouterLink class="nav-link" to="/login">Login</RouterLink>
+        </li>
+      </ul>
     </div>
   </nav>
 
@@ -10,8 +23,19 @@
   </div>
 </template>
 
+<script setup>
+import { currentUser, logout } from './utils/auth.js'
+import { computed } from 'vue'
+
+const user = computed(() => currentUser.value)
+const doLogout = async () => {
+  await logout()
+}
+</script>
+
 <style lang="css">
 p {
   white-space: pre-line;
 }
 </style>
+

--- a/frontend/src/components/LoginView.vue
+++ b/frontend/src/components/LoginView.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="row justify-content-center">
+    <div class="col-md-4">
+      <form @submit.prevent="submit">
+        <h1 class="h5 mb-3">Login</h1>
+        <div class="mb-3">
+          <label class="form-label">Username</label>
+          <input v-model="username" class="form-control" required />
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Password</label>
+          <input v-model="password" type="password" class="form-control" required />
+        </div>
+        <button class="btn btn-primary">Login</button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { login } from '../utils/auth.js'
+
+const router = useRouter()
+const username = ref('')
+const password = ref('')
+
+const submit = async () => {
+  try {
+    await login(username.value, password.value)
+    router.push('/')
+  } catch (e) {
+    alert('Login failed')
+  }
+}
+</script>

--- a/frontend/src/components/ProjectDetail.vue
+++ b/frontend/src/components/ProjectDetail.vue
@@ -78,7 +78,7 @@
       </template>
       
       <!-- Stats panel -->
-      <StatsPanel :problems="project.problems" />
+      <StatsPanel :project-id="project.id" :problems="project.problems" />
     </div>
 
     <div class="col-md-7">

--- a/frontend/src/components/RegisterUser.vue
+++ b/frontend/src/components/RegisterUser.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="row justify-content-center">
+    <div class="col-md-4">
+      <form @submit.prevent="submit">
+        <h1 class="h5 mb-3">Register User</h1>
+        <div class="mb-3">
+          <label class="form-label">Username</label>
+          <input v-model="username" class="form-control" required />
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Password</label>
+          <input v-model="password" type="password" class="form-control" required />
+        </div>
+        <div class="form-check mb-3">
+          <input class="form-check-input" type="checkbox" id="admin" v-model="isAdmin" />
+          <label class="form-check-label" for="admin">Admin</label>
+        </div>
+        <button class="btn btn-primary">Create</button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import axios from 'axios'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const username = ref('')
+const password = ref('')
+const isAdmin = ref(false)
+
+const submit = async () => {
+  await axios.post('/api/register', { username: username.value, password: password.value, is_admin: isAdmin.value })
+  router.push('/')
+}
+</script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,10 +1,12 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
+import { fetchCurrentUser } from './utils/auth.js'
 
 // Classic styling
 import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap-icons/font/bootstrap-icons.css'
 import 'bootstrap/dist/js/bootstrap.bundle.min.js'
 
+fetchCurrentUser()
 createApp(App).use(router).mount('#app')

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -2,12 +2,17 @@ import { createRouter, createWebHistory } from 'vue-router'
 import ProjectList from './components/ProjectList.vue'
 import ProjectDetail from './components/ProjectDetail.vue'
 import ProblemDetail from './components/ProblemDetail.vue'
+import LoginView from './components/LoginView.vue'
+import RegisterUser from './components/RegisterUser.vue'
 
 export default createRouter({
   history: createWebHistory(),
   routes: [
     { path: '/', component: ProjectList },
+    { path: '/login', component: LoginView },
+    { path: '/register', component: RegisterUser },
     { path: '/projects/:id', component: ProjectDetail, props: true },
     { path: '/problems/:id', component: ProblemDetail, props: true },
   ]
 })
+

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -1,0 +1,19 @@
+import { ref } from 'vue'
+import axios from 'axios'
+
+export const currentUser = ref(null)
+
+export async function fetchCurrentUser() {
+  const { data } = await axios.get('/api/current_user')
+  currentUser.value = data
+}
+
+export async function login(username, password) {
+  await axios.post('/api/login', { username, password })
+  await fetchCurrentUser()
+}
+
+export async function logout() {
+  await axios.post('/api/logout')
+  currentUser.value = null
+}


### PR DESCRIPTION
## Summary
- add User and Evaluation models
- create admin if database has no users
- add authentication routes and helpers
- store evaluations per user
- compute project stats and Cohen's kappa
- update Vue app for login, register, and stats panel

## Testing
- `python -m py_compile backend/*.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684758312d5883289baadb0de356f68e