### PR TITLE
Enforce login for problem actions and new user workflow

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -25,9 +25,12 @@ class Problem(db.Model):
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
-    password_hash = db.Column(db.String(128), nullable=False)
+    # password_hash can be null so new users can set their password on first login
+    password_hash = db.Column(db.String(128), nullable=True)
     is_admin = db.Column(db.Boolean, default=False)
-    evaluations = db.relationship("Evaluation", backref="user", cascade="all, delete-orphan")
+    evaluations = db.relationship(
+        "Evaluation", backref="user", cascade="all, delete-orphan"
+    )
 
 
 class Evaluation(db.Model):

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -40,8 +40,20 @@ def admin_required(f):
 def login():
     data = request.json or {}
     user = User.query.filter_by(username=data.get("username")).first()
-    if not user or not check_password_hash(user.password_hash, data.get("password", "")):
+    if not user:
         abort(401)
+
+    password = data.get("password")
+    # If the user has no password set yet, require them to set one
+    if user.password_hash is None:
+        if not password:
+            return jsonify({"set_password_required": True}), 400
+        user.password_hash = generate_password_hash(password)
+        db.session.commit()
+
+    if not check_password_hash(user.password_hash, password or ""):
+        abort(401)
+
     session["user_id"] = user.id
     return jsonify({"username": user.username, "is_admin": user.is_admin})
 
@@ -64,16 +76,27 @@ def get_current_user_route():
 @admin_required
 def register_user():
     data = request.json or {}
-    if not data.get("username") or not data.get("password"):
+    if not data.get("username"):
         abort(400)
     if User.query.filter_by(username=data["username"]).first():
         return jsonify({"error": "Username already exists"}), 400
-    user = User(username=data["username"],
-                password_hash=generate_password_hash(data["password"]),
-                is_admin=bool(data.get("is_admin")))
+    user = User(
+        username=data["username"],
+        password_hash=None,
+        is_admin=bool(data.get("is_admin")),
+    )
     db.session.add(user)
     db.session.commit()
     return jsonify({"id": user.id, "username": user.username, "is_admin": user.is_admin}), 201
+
+
+@api.route("/users/<int:uid>/reset_password", methods=["POST"])
+@admin_required
+def reset_password(uid):
+    user = User.query.get_or_404(uid)
+    user.password_hash = None
+    db.session.commit()
+    return "", 204
 
 # ---- Projects ----
 @api.route("/projects", methods=["GET"])
@@ -81,6 +104,7 @@ def list_projects():
     return jsonify([p_to_dict(p) for p in Project.query.order_by(Project.created_at.desc())])
 
 @api.route("/projects", methods=["POST"])
+@login_required
 def create_project():
     data = request.json or {}
     p = Project(name=data.get("name"),
@@ -174,6 +198,7 @@ def project_stats(pid):
 
 # ---- Problems ----
 @api.route("/projects/<int:pid>/problems", methods=["POST"])
+@login_required
 def create_problem(pid):
     project = Project.query.get_or_404(pid)
     target_objs: str = request.json.get("target_objectives", "")
@@ -246,6 +271,7 @@ def evaluate_problem(qid):
 
 
 @api.route("/problems/<int:qid>/answer", methods=["POST"])
+@login_required
 def answer_problem(qid):
     problem = Problem.query.get_or_404(qid)
     problem.sample_answer = generate_answer(problem.generated_problem, problem.type)

--- a/frontend/src/components/LoginView.vue
+++ b/frontend/src/components/LoginView.vue
@@ -7,7 +7,7 @@
           <label class="form-label">Username</label>
           <input v-model="username" class="form-control" required />
         </div>
-        <div class="mb-3">
+        <div class="mb-3" v-if="showPassword">
           <label class="form-label">Password</label>
           <input v-model="password" type="password" class="form-control" required />
         </div>
@@ -25,13 +25,18 @@ import { login } from '../utils/auth.js'
 const router = useRouter()
 const username = ref('')
 const password = ref('')
+const showPassword = ref(false)
 
 const submit = async () => {
   try {
-    await login(username.value, password.value)
+    await login(username.value, showPassword.value ? password.value : undefined)
     router.push('/')
   } catch (e) {
-    alert('Login failed')
+    if (e.response && e.response.data && e.response.data.set_password_required) {
+      showPassword.value = true
+    } else {
+      alert('Login failed')
+    }
   }
 }
 </script>

--- a/frontend/src/components/RegisterUser.vue
+++ b/frontend/src/components/RegisterUser.vue
@@ -7,10 +7,6 @@
           <label class="form-label">Username</label>
           <input v-model="username" class="form-control" required />
         </div>
-        <div class="mb-3">
-          <label class="form-label">Password</label>
-          <input v-model="password" type="password" class="form-control" required />
-        </div>
         <div class="form-check mb-3">
           <input class="form-check-input" type="checkbox" id="admin" v-model="isAdmin" />
           <label class="form-check-label" for="admin">Admin</label>
@@ -28,11 +24,10 @@ import { useRouter } from 'vue-router'
 
 const router = useRouter()
 const username = ref('')
-const password = ref('')
 const isAdmin = ref(false)
 
 const submit = async () => {
-  await axios.post('/api/register', { username: username.value, password: password.value, is_admin: isAdmin.value })
+  await axios.post('/api/register', { username: username.value, is_admin: isAdmin.value })
   router.push('/')
 }
 </script>

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -9,8 +9,9 @@ export async function fetchCurrentUser() {
 }
 
 export async function login(username, password) {
-  await axios.post('/api/login', { username, password })
+  const res = await axios.post('/api/login', { username, password })
   await fetchCurrentUser()
+  return res
 }
 
 export async function logout() {


### PR DESCRIPTION
## Summary
- allow `User.password_hash` to be null
- require login for creating projects, problems and answers
- allow admins to create accounts without passwords and reset them
- login endpoint sets password on first login
- adjust login component for password setup flow
- remove password field from user registration form

## Testing
- `python -m py_compile backend/*.py`
- `npm test --silent` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6851d4b88f948328ba0acb6f5a412966