### PR TITLE
Improve login flow for password setup

### DIFF
--- a/frontend/src/components/LoginView.vue
+++ b/frontend/src/components/LoginView.vue
@@ -7,11 +7,27 @@
           <label class="form-label">Username</label>
           <input v-model="username" class="form-control" required />
         </div>
-        <div class="mb-3" v-if="showPassword">
+        <div class="mb-3" v-if="showPassword || settingPassword">
           <label class="form-label">Password</label>
-          <input v-model="password" type="password" class="form-control" required />
+          <input
+            v-model="password"
+            type="password"
+            class="form-control"
+            required
+          />
         </div>
-        <button class="btn btn-primary">Login</button>
+        <div class="mb-3" v-if="settingPassword">
+          <label class="form-label">Confirm Password</label>
+          <input
+            v-model="confirmPassword"
+            type="password"
+            class="form-control"
+            required
+          />
+        </div>
+        <button class="btn btn-primary">
+          {{ settingPassword ? 'Set Password' : 'Login' }}
+        </button>
       </form>
     </div>
   </div>
@@ -25,14 +41,27 @@ import { login } from '../utils/auth.js'
 const router = useRouter()
 const username = ref('')
 const password = ref('')
+const confirmPassword = ref('')
 const showPassword = ref(false)
+const settingPassword = ref(false)
 
 const submit = async () => {
+  if (settingPassword.value && password.value !== confirmPassword.value) {
+    alert('Passwords do not match')
+    return
+  }
+
   try {
-    await login(username.value, showPassword.value ? password.value : undefined)
+    await login(
+      username.value,
+      showPassword.value || settingPassword.value ? password.value : undefined
+    )
     router.push('/')
   } catch (e) {
     if (e.response && e.response.data && e.response.data.set_password_required) {
+      settingPassword.value = true
+      showPassword.value = true
+    } else if (!showPassword.value) {
       showPassword.value = true
     } else {
       alert('Login failed')


### PR DESCRIPTION
## Summary
- enhance login UI to handle initial password setup
- add confirm password field and better error handling

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68530d8e98c88328bdf9e0995fdc875a